### PR TITLE
deleted type "number" to default it to doubles

### DIFF
--- a/sc/cryoenv-assembly/command-model.conf
+++ b/sc/cryoenv-assembly/command-model.conf
@@ -22,7 +22,6 @@ receive = [
 	    	{
 		    	name 		= targetTemperature
 		    	description = "The target temperature for the output"
-		    	type 		= number
 	    	}
 		]
 	}
@@ -72,7 +71,6 @@ receive = [
 	    	{
 		    	name 		= targetTemperature
 		    	description = "The target temperature for the output"
-		    	type 		= number
 	    	}
 		]
 	}
@@ -122,7 +120,6 @@ receive = [
 	    	{
 		    	name 		= targetTemperature
 		    	description = "The target temperature for the output"
-		    	type 		= number
 	    	}
 		]
 	}
@@ -172,7 +169,6 @@ receive = [
 	    	{
 		    	name 		= targetTemperature
 		    	description = "The target temperature for the output"
-		    	type 		= number
 	    	}
 		]
 	}


### PR DESCRIPTION
Very simple bug fix on number type. Deleted number types to default to double.