### PR TITLE
Updates for DMS FDR

### DIFF
--- a/csro/csro-assembly/component-model.conf
+++ b/csro/csro-assembly/component-model.conf
@@ -1,5 +1,5 @@
 subsystem = IRIS
-component = iris.csro
+component = csro
 
 modelVersion = "2.0"
 title = "CSRO"

--- a/csro/oiwfs-detector-assembly/command-model.conf
+++ b/csro/oiwfs-detector-assembly/command-model.conf
@@ -510,7 +510,7 @@ At Completion:
                 }
             }
             {
-                name = rtcOffset
+                name = rtcOffsetState
                 description = "Indicate if following RTC offsets for each probe"
                 type = array
                 dimensions: [3]

--- a/csro/oiwfs-detector-assembly/publish-model.conf
+++ b/csro/oiwfs-detector-assembly/publish-model.conf
@@ -190,7 +190,7 @@ publish {
             }
         }
         {
-            name = rtcOffset
+            name = rtcOffsetState
             description = "Indicate if following RTC offsets for each probe"
             type = array
             dimensions: [3]

--- a/drs/drs-assembly/service-model.conf
+++ b/drs/drs-assembly/service-model.conf
@@ -1,0 +1,51 @@
+subsystem = IRIS
+component = drs
+
+requires = [
+  {
+    subsystem = DMS
+    component = ScienceDataAccessService
+    name = "Science Data Access Service"
+    paths = [
+      {
+        // download files based on URIs
+        path = "/retrieve"
+        method = get
+      },
+      {
+        // use exposureIds to get URIs
+        path = /science/file
+        method = get
+      }
+    ]
+  },
+  {
+    subsystem = DMS
+    component = CalibrationDataService
+    name = "Calibration Data Service"
+    paths = [
+      {
+        // search for calibration files
+        path = /calibration/search
+        method = get
+      },
+      {
+        // search for calibration files for given exposure
+        path = "/calibration/exposure/{exposureId}"
+        method = get
+      }
+    ]
+  },
+  {
+    subsystem = DMS
+    component = ScienceDataStorageService
+    name = "Science Data Storage Service"
+    paths = [
+      {
+        // store readout file
+        path = "/ancillary/exposure/{exposureId}"
+        method = post
+      }
+    ]
+  }
+]

--- a/ifs/scale-assembly/publish-model.conf
+++ b/ifs/scale-assembly/publish-model.conf
@@ -59,21 +59,18 @@ publish {
 	    			type = integer
 	    			units = counts 
 	    			minimum = 0
-	    			default = -1 
 	    		}
 	    		{
 	    			name = switch
 	    			description = "Current switch value of pickoff mirror mechanism." 
 	    			type = integer
 	    			minimum = 0
-	    			default =-1 
 	    		}
 	    		{
 	    			name = positionNumber
 	    			description  = "Current position number of pickoff mirror mechanism."
 	    			type = integer
 	    			minimum = 0 
-	    			default = -1
 	    		}
 	    		{
 	    			name = targetPosition
@@ -87,27 +84,23 @@ publish {
 	    			type = integer
 	    			units = counts 
 	    			minimum = 0
-	    			default = -1 
 	    		}
 	    		{
 	    			name = targetSwitch
 	    			description = "Switch value at target position for pickoff mirror mechanism." 
 	    			type = integer
 	    			minimum = 0
-	    			default =-1 
 	    		}
 	    		{
 	    			name = targetPositionNumber
 	    			description  = "Target position number of pickoff mirror mechanism."
 	    			type = integer
 	    			minimum = 0 
-	    			default = -1
 	    		}
 	    		{
 	    			name = status
 	    			description  = "Current status of pickoff mirror mechanism"
 	    			type = string
-	    			default = UNKNOWN
 	    		}
 	    	]
 	    }
@@ -130,21 +123,18 @@ publish {
 	    			type = integer
 	    			units = counts 
 	    			minimum = 0
-	    			default = -1 
 	    		}
 	    		{
 	    			name = switch
 	    			description = "Current switch value of periscope mirror mechanism." 
 	    			type = integer
 	    			minimum = 0
-	    			default =-1 
 	    		}
 	    		{
 	    			name = positionNumber
 	    			description  = "Current position number of periscope mirror mechanism."
 	    			type = integer
 	    			minimum = 0 
-	    			default = -1
 	    		}
 	    		{
 	    			name = targetPosition
@@ -158,27 +148,23 @@ publish {
 	    			type = integer
 	    			units = counts 
 	    			minimum = 0
-	    			default = -1 
 	    		}
 	    		{
 	    			name = targetSwitch
 	    			description = "Switch value at target position for periscope mirror mechanism." 
 	    			type = integer
 	    			minimum = 0
-	    			default =-1 
 	    		}
 	    		{
 	    			name = targetPositionNumber
 	    			description  = "Target position number of periscope mirror mechanism."
 	    			type = integer
 	    			minimum = 0 
-	    			default = -1
 	    		}
 	    		{
 	    			name = status
 	    			description  = "Current status of periscope mirror mechanism"
 	    			type = string
-	    			default = UNKNOWN
 	    		}
 	    	]
 	    }
@@ -201,21 +187,18 @@ publish {
 	    			type = integer
 	    			units = counts 
 	    			minimum = 0
-	    			default = -1 
 	    		}
 	    		{
 	    			name = switch
 	    			description = "Current switch value of first optics mechanism." 
 	    			type = integer
 	    			minimum = 0
-	    			default =-1 
 	    		}
 	    		{
 	    			name = positionNumber
 	    			description  = "Current position number of first optics mechanism."
 	    			type = integer
 	    			minimum = 0 
-	    			default = -1
 	    		}
 	    		{
 	    			name = targetPosition
@@ -229,21 +212,18 @@ publish {
 	    			type = integer
 	    			units = counts 
 	    			minimum = 0
-	    			default = -1 
 	    		}
 	    		{
 	    			name = targetSwitch
 	    			description = "Switch value at target position for first optics mechanism." 
 	    			type = integer
 	    			minimum = 0
-	    			default =-1 
 	    		}
 	    		{
 	    			name = targetPositionNumber
 	    			description  = "Target position number of first optics mechanism."
 	    			type = integer
 	    			minimum = 0 
-	    			default = -1
 	    		}
 	    		{
 	    			name = status
@@ -272,21 +252,18 @@ publish {
 	    			type = integer
 	    			units = counts 
 	    			minimum = 0
-	    			default = -1 
 	    		}
 	    		{
 	    			name = switch
 	    			description = "Current switch value of second optics mechanism." 
 	    			type = integer
 	    			minimum = 0
-	    			default =-1 
 	    		}
 	    		{
 	    			name = positionNumber
 	    			description  = "Current position number of second optics mechanism."
 	    			type = integer
 	    			minimum = 0 
-	    			default = -1
 	    		}
 	    		{
 	    			name = targetPosition
@@ -300,21 +277,18 @@ publish {
 	    			type = integer
 	    			units = counts 
 	    			minimum = 0
-	    			default = -1 
 	    		}
 	    		{
 	    			name = targetSwitch
 	    			description = "Switch value at target position for second optics mechanism." 
 	    			type = integer
 	    			minimum = 0
-	    			default =-1 
 	    		}
 	    		{
 	    			name = targetPositionNumber
 	    			description  = "Target position number of second optics mechanism."
 	    			type = integer
 	    			minimum = 0 
-	    			default = -1
 	    		}
 	    		{
 	    			name = status

--- a/ifs/spectralres-assembly/publish-model.conf
+++ b/ifs/spectralres-assembly/publish-model.conf
@@ -295,13 +295,11 @@ publish {
     			name = current
     			description  = "Current spectral resolution." 
     			enum = [4000-Z, 4000-Y, 4000-J, 4000-H, 4000-K, "4000-H+K", 8000-Z, 8000-Y, 8000-J, 8000-H, 8000-Kn1-3, 8000-Kn4-5, 8000-Kbb, 10000-Z, 10000-Y, 10000-J, 10000-H, 1000-K, Mirror]
-    			default = TBD 
     		}
     		{
     			name = target
     			description  = "Target spectral resolution." 
     			enum = [4000-Z, 4000-Y, 4000-J, 4000-H, 4000-K, "4000-H+K", 8000-Z, 8000-Y, 8000-J, 8000-H, 8000-Kn1-3, 8000-Kn4-5, 8000-Kbb, 10000-Z, 10000-Y, 10000-J, 10000-H, 1000-K, Mirror]
-    			default = TBD
     		}
     	]
     }
@@ -326,7 +324,6 @@ publish {
     			name = rawPosition
     			description = "Current raw position of spectral resolution grating mechanism."
     			type = integer
-    			default = -1
     			units = counts
     		}
     		{
@@ -334,14 +331,12 @@ publish {
     			description  = "Current switch value of spectral resolution grating mechanism."
     			type = integer
     			minimum = 0
-    			default = -1 
     		}
     		{
     			name = positionNumber
     			description = "Current position number of spectral resolution grating mechanism."
     			type = integer
     			minimum = 0
-    			default =-1 
     		}
     		{
     			name = targetPosition
@@ -352,28 +347,24 @@ publish {
     			name = targetRawPosition
     			description = "Target raw position of spectral resolution grating mechanism." 
     			type = integer
-    			default = -1
-    			units = counts 
+    			units = counts
     		}
     		{
     			name = targetSwitch
     			description  = "Switch value at target position for spectral resolution grating mechanism."
     			type = integer
     			minimum = 0
-    			default = -1
     		}
     		{
     			name = targetPositionNumber
     			description = "Target position number of spectral resolution grating mechanism." 
     			type = integer
     			minimum = 0 
-    			default = -1
     		}
     		{
     			name = status
     			description = "Current status of spectral resolution grating mechanism."
     			type = string
-    			default = UNKNOWN
     		}
     	]
     }
@@ -398,7 +389,6 @@ publish {
     			name = rawPosition
     			description = "Current raw position of spectral resolution lenslet mask mechanism."
     			type = integer
-    			default = -1
     			units = counts
     		}
     		{
@@ -406,14 +396,12 @@ publish {
     			description  = "Current switch value of spectral resolution lenslet mask mechanism."
     			type = integer
     			minimum = 0
-    			default = -1 
     		}
     		{
     			name = positionNumber
     			description = "Current position number of spectral resolution lenslet mask mechanism."
     			type = integer
     			minimum = 0
-    			default =-1 
     		}
     		{
     			name = targetPosition
@@ -424,28 +412,24 @@ publish {
     			name = targetRawPosition
     			description = "Target raw position of spectral resolution lenslet mask mechanism." 
     			type = integer
-    			default = -1
-    			units = counts 
+    			units = counts
     		}
     		{
     			name = targetSwitch
     			description  = "Switch value at target position for spectral resolution lenslet mask mechanism."
     			type = integer
     			minimum = 0
-    			default = -1
     		}
     		{
     			name = targetPositionNumber
     			description = "Target position number of spectral resolution lenslet mask mechanism." 
     			type = integer
     			minimum = 0 
-    			default = -1
     		}
     		{
     			name = status
     			description = "Current status of spectral resolution lenslet mask mechanism."
     			type = string
-    			default = UNKNOWN
     		}
     	]
     }
@@ -470,7 +454,6 @@ publish {
     			name = rawPosition
     			description = "Current raw position of spectral resolution slicer mask mechanism."
     			type = integer
-    			default = -1
     			units = counts
     		}
     		{
@@ -478,14 +461,12 @@ publish {
     			description  = "Current switch value of spectral resolution slicer mask mechanism."
     			type = integer
     			minimum = 0
-    			default = -1 
     		}
     		{
     			name = positionNumber
     			description = "Current position number of spectral resolution slicer mask mechanism."
     			type = integer
     			minimum = 0
-    			default =-1 
     		}
     		{
     			name = targetPosition
@@ -496,28 +477,24 @@ publish {
     			name = targetRawPosition
     			description = "Target raw position of spectral resolution slicer mask mechanism." 
     			type = integer
-    			default = -1
-    			units = counts 
+    			units = counts
     		}
     		{
     			name = targetSwitch
     			description  = "Switch value at target position for spectral resolution slicer mask mechanism."
     			type = integer
     			minimum = 0
-    			default = -1
     		}
     		{
     			name = targetPositionNumber
     			description = "Target position number of spectral resolution slicer mask mechanism." 
     			type = integer
     			minimum = 0 
-    			default = -1
     		}
     		{
     			name = status
     			description = "Current status of spectral resolution slicer mask mechanism."
     			type = string
-    			default = UNKNOWN
     		}
     	]
     }


### PR DESCRIPTION
I updated the model files for prep for DMS FDR.  The changes are modest and hopefully not controversial.  These versions of the model files are not expected to be ready for IRIS FDR; they can be updated after the DMS FDR prior to the IRIS Software FDR or full instrument FDR.  The SDB resulting from these changes will not be placed under change control at this time.

A summary of the changes:

  - Added service interface for DRS Assembly for service interactions with DMS.
  - Fixed some syntactical errors due to ICD-DB schema changes:  removed default values that did not match data ranges.
  - Fixed duplicate parameter name in oiwfs-detector assembly publish and command models 
  - Fixed IRIS CRSO component name from "iris.csro" to "csro".  Subsystem name is prepended to component name in CSW prefix and shouldn't be in component name.
 